### PR TITLE
fix(Pilot/Compendium): Remove HA Source from Plasma Talons

### DIFF
--- a/weapons.json
+++ b/weapons.json
@@ -34,7 +34,6 @@
     "id": "mw_tokugawa_alt_enkidu_integrated",
     "name": "Plasma Talons",
     "mount": "Auxiliary",
-    "source": "HA",
     "type": "Melee",
     "range": [
       {


### PR DESCRIPTION
# Description

Removes HA Source from Plasma Talons to match the paradigm of other integrated weapons & remove them from the general weapons list.

Recreating this PR now that I did my homework and checked how other integrated weapons are formatted (and simply following the advice of the Issue-creator 😓 ).

## Issue Number

Closes [#1547](https://github.com/massif-press/compcon/issues/1547), compcon

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)