### PR TITLE
fix(Compendium):Add Quick tag to Snapdragon & some deployables

### DIFF
--- a/systems.json
+++ b/systems.json
@@ -101,6 +101,7 @@
       {
         "type": "Project",
         "name": "Emplacement",
+        "activation": "Quick",
         "instances": 1,
         "cost": 1,
         "size": 1,
@@ -110,6 +111,7 @@
       {
         "type": "Project",
         "name": "Snare Foam",
+        "activation": "Quick",
         "instances": 1,
         "cost": 1,
         "size": 1,
@@ -119,6 +121,7 @@
       {
         "type": "Project",
         "name": "Damping Station",
+        "activation": "Quick",
         "instances": 1,
         "cost": 1,
         "size": 1,
@@ -128,6 +131,7 @@
       {
         "type": "Project",
         "name": "Armor Pack",
+        "activation": "Quick",
         "instances": 1,
         "cost": 1,
         "size": 1,
@@ -185,6 +189,9 @@
       },
       {
         "id": "tg_unique"
+      },
+      {
+        "id": "tg_quick_action"
       }
     ],
     "source": "EXOTIC",
@@ -269,6 +276,7 @@
       {
         "name": "Markey’s Fusebox",
         "type": "Mine",
+        "activation": "Quick",
         "size": 0.5,
         "hp": 10,
         "edef": 5,


### PR DESCRIPTION
# Description

Adds Quick Action tag to Snapdragon Launcher system.  Also includes some redundant "Quick" activations to deployables missing them; CompCon marks deployables without `activation` as Quick by default, but this change should add a little redundancy in case COMP/CON's logic changes.

## Issue Number

Closes [#1594](https://github.com/massif-press/compcon/issues/1594) from compcon

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)