### PR TITLE
fix(Compendium):add 1/scene to Fragment of Beggar One

### DIFF
--- a/systems.json
+++ b/systems.json
@@ -326,6 +326,7 @@
       }
     ],
     "source": "EXOTIC",
+    "effect": "<p>1/scene, you may take one of the following Full Tech actions:</p>",
     "actions": [
       {
         "name": "Whisper of Cascade",


### PR DESCRIPTION
# Description
Adds an "effect" line to Fragment of Beggar One to specify that the Full Tech actions can only be taken 1/scene, matching the text that exists in NRfaW Act I.

## Issue Number
Closes [CompCon #1637](https://github.com/massif-press/compcon/issues/1637)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)