### PR TITLE
correct Carapace Cladding to be System instead of AI

### DIFF
--- a/systems.json
+++ b/systems.json
@@ -296,7 +296,7 @@
   {
     "id": "ms_exo_carapace_cladding",
     "name": "Carapace Cladding",
-    "type": "AI",
+    "type": "System",
     "sp": 1,
     "tags": [
       {


### PR DESCRIPTION
Minor typo. Change Carapace Cladding to be of Type "System" instead of type "AI".