### PR TITLE
fix(data): Add secondary Defender role to Worldkiller

### DIFF
--- a/lib/frames.json
+++ b/lib/frames.json
@@ -294,7 +294,8 @@
     "source": "HA",
     "name": "“Worldkiller” Genghis Mk I",
     "mechtype": [
-      "Striker"
+      "Striker",
+      "Defender"
     ],
     "y_pos": 25,
     "license_level": 2,


### PR DESCRIPTION
Add a missing secondary Defender role to the Genghis Mk I that was present in the PDF version of Wallflower Act 1.